### PR TITLE
refact(endsWith): endsWith is fast than regexp

### DIFF
--- a/benchmark/arguments-to-args.js
+++ b/benchmark/arguments-to-args.js
@@ -26,19 +26,19 @@ console.log('forLoop(0, 1, 2, 3, 4, 5, 6, 7): %j', forLoop(0, 1, 2, 3, 4, 5, 6, 
 suite
 
 .add('Array.prototype.slice.call(arguments)', function() {
-  slice(0, 1, 2, 3, 4, 5, 6, 7)
+  slice(0, 1, 2, 3, 4, 5, 6, 7);
 })
 .add('Array.prototype.slice.call(arguments, 0)', function() {
-  slice0(0, 1, 2, 3, 4, 5, 6, 7)
+  slice0(0, 1, 2, 3, 4, 5, 6, 7);
 })
 .add('for(var i = 0; i < args.length; i++) {}', function() {
-  forLoop(0, 1, 2, 3, 4, 5, 6, 7)
+  forLoop(0, 1, 2, 3, 4, 5, 6, 7);
 })
 
 .on('cycle', function(event) {
   benchmarks.add(event.target);
 })
-.on('start', function(event) {
+.on('start', function() {
   console.log('\n  arguments to args Benchmark\n  node version: %s, date: %s\n  Starting...',
     process.version, Date());
 })

--- a/benchmark/ends-with.js
+++ b/benchmark/ends-with.js
@@ -1,0 +1,70 @@
+var Benchmark = require('benchmark');
+var benchmarks = require('beautify-benchmark');
+
+var suite = new Benchmark.Suite();
+
+function endsWith(str) {
+  return str.endsWith('.properties');
+}
+
+function indexOf(str) {
+  return str.indexOf('.properties') === str.length - 11;
+}
+
+function regexp(str) {
+  return /\.properties$/.test(str);
+}
+
+console.log('true:');
+console.log('  endsWith: %j', endsWith('filename.properties'));
+console.log('  indexOf: %j', indexOf('filename.properties'));
+console.log('  regexp: %j', regexp('filename.properties'));
+console.log('false:');
+console.log('  endsWith: %j', endsWith('filename'));
+console.log('  indexOf: %j', indexOf('filename'));
+console.log('  regexp: %j', regexp('filename'));
+
+suite
+
+.add('endsWith', function() {
+  endsWith('filename.properties');
+  endsWith('filename');
+})
+.add('indexOf', function() {
+  indexOf('filename.properties');
+  indexOf('filename');
+})
+.add('regexp', function() {
+  regexp('filename.properties');
+  regexp('filename');
+})
+
+.on('cycle', function(event) {
+  benchmarks.add(event.target);
+})
+.on('start', function() {
+  console.log('\n  endsWith Benchmark\n  node version: %s, date: %s\n  Starting...',
+    process.version, Date());
+})
+.on('complete', function done() {
+  benchmarks.log();
+})
+.run({ async: false });
+
+// true:
+//   endsWith: true
+//   indexOf: true
+//   regexp: true
+// false:
+//   endsWith: false
+//   indexOf: false
+//   regexp: false
+//
+//   endsWith Benchmark
+//   node version: v2.2.1, date: Sun Aug 30 2015 14:39:14 GMT+0800 (CST)
+//   Starting...
+//   3 tests completed.
+//
+//   endsWith x 13,491,036 ops/sec ±0.55% (101 runs sampled)
+//   indexOf  x 13,796,553 ops/sec ±0.57% (99 runs sampled)
+//   regexp   x  4,772,744 ops/sec ±0.57% (98 runs sampled)

--- a/index.js
+++ b/index.js
@@ -35,16 +35,14 @@ module.exports = function (app, options) {
     var names = fs.readdirSync(localeDir);
     for (var i = 0; i < names.length; i++) {
       var name = names[i];
-      if (!/\.(?:js|json|properties)$/.test(name)) {
-        continue;
-      }
       var filepath = path.join(localeDir, name);
       // support en_US.js => en-US.js
       var locale = formatLocale(name.split('.')[0]);
-      if (/\.properties$/.test(name)) {
-        resources[locale] = ini.parse(fs.readFileSync(filepath, 'utf8'));
-      } else {
+
+      if (name.endsWith('.js') || name.endsWith('.json')) {
         resources[locale] = require(filepath);
+      } else if (name.endsWith('.properties')) {
+        resources[locale] = ini.parse(fs.readFileSync(filepath, 'utf8'));
       }
     }
   }


### PR DESCRIPTION
```
$ node benchmark/ends-with.js 

true:
  endsWith: true
  indexOf: true
  regexp: true
false:
  endsWith: false
  indexOf: false
  regexp: false

  endsWith Benchmark
  node version: v2.2.1, date: Sun Aug 30 2015 20:49:13 GMT+0800 (CST)
  Starting...
  3 tests completed.

  endsWith x 13,620,742 ops/sec ±0.61% (101 runs sampled)
  indexOf  x 13,483,348 ops/sec ±0.80% (99 runs sampled)
  regexp   x  4,684,963 ops/sec ±0.80% (99 runs sampled)
```

<img width="573" alt="2015-08-30 20 49 58" src="https://cloud.githubusercontent.com/assets/143572/9567313/c0340356-4f58-11e5-95ae-bbfed0fafda1.png">
