### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/koajs/locales",
   "repository": {
     "type": "git",
-    "url": "git://github.com/koajs/locales.git",
+    "url": "git+https://github.com/koajs/locales.git",
     "web": "https://github.com/koajs/locales"
   },
   "bugs": {


### PR DESCRIPTION
## Summary
- update package.json repository.url from git:// to git+https://
- keep the existing koajs homepage, bug tracker, and web metadata unchanged

## Validation
- node metadata assertion for repository.url, repository.web, bugs.url, and homepage
- package.json JSON parse via the metadata assertion
- git diff --check
- git ls-remote https://github.com/koajs/locales.git HEAD